### PR TITLE
Fix IE11 error on fitBoundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dagre-d3-react",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "React component for Dagre-D3 rendering library",
 	"main": "build/index.tsx",
 	"types": "build/index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -110,7 +110,7 @@ class DagreGraph extends Component<GraphProps> {
 		if (fitBoundaries) {
 			//@BertCh recommendation for fitting boundaries
 			const bounds = inner.node().getBBox()
-			const parent = inner.node().parentElement
+			const parent = inner.node().parentElement || inner.node().parentNode
 			const fullWidth = parent.clientWidth || parent.parentNode.clientWidth
 			const fullHeight = parent.clientHeight || parent.parentNode.clientHeight
 			const width = bounds.width


### PR DESCRIPTION
This is my first time contributing so I'm not quite sure how to do this, however I had an error on IE11 when using `fitBoundaries`. 

Error:
> Unable to get property 'clientWidth' of undefined or null reference

Should I have updated the `build` folder as well by running `npm install && npm run build`?
