### PR TITLE
Options->config, specify no fill on example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ReactDOM.render(
 		<DagreGraph
 			nodes={nodes}
 			links={links}
-			options={{
+			config={{
 				rankdir: 'LR',
 				align: 'UL',
 				ranker: 'tight-tree'
@@ -226,7 +226,8 @@ let data = {
       label: 'TO',
       config: {
 			  arrowheadStyle: 'display: none',
-			  curve: d3.curveBasis
+			  curve: d3.curveBasis,
+			  style: 'fill:none'
       }
     },
   ]


### PR DESCRIPTION
* Rename the options prop to config so it actually works
* Include style: 'fill:none' in the example path style (since the default fill behavior wasn't obvious to me)