### PR TITLE
make react peer dependency greater than or equal to 16.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dagre-d3-react",
-  "version": "0.1.8",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"typescript": "^3.6.2"
 	},
 	"peerDependencies": {
-		"react": "16.9.0",
-		"react-dom": "16.9.0"
+		"react": ">=16.9.0",
+		"react-dom": ">=16.9.0"
 	}
 }


### PR DESCRIPTION
Updating peer dependencies for react and react-do to be >=16.9 rather than == 16.9 per issue #26